### PR TITLE
Add .NET 10 support and update packages to resolve vulnerabilities

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 env:
-  NETCORE_VERSION: '9.0.x'
+  NETCORE_VERSION: '10.0.x'
 
 jobs:
   build:

--- a/src/TailoredApps.Shared.Email.Office365/TailoredApps.Shared.Email.Office365.csproj
+++ b/src/TailoredApps.Shared.Email.Office365/TailoredApps.Shared.Email.Office365.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 		<AssemblyName>TailoredApps.Shared.Email.Office365</AssemblyName>
 		<RootNamespace>TailoredApps.Shared.Email.Office365</RootNamespace>

--- a/src/TailoredApps.Shared.Email/TailoredApps.Shared.Email.csproj
+++ b/src/TailoredApps.Shared.Email/TailoredApps.Shared.Email.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 
@@ -22,6 +22,10 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />

--- a/src/TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore/TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore.csproj
+++ b/src/TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore/TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/src/TailoredApps.Shared.EntityFramework/TailoredApps.Shared.EntityFramework.csproj
+++ b/src/TailoredApps.Shared.EntityFramework/TailoredApps.Shared.EntityFramework.csproj
@@ -2,12 +2,15 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 

--- a/src/TailoredApps.Shared.ExceptionHandling/TailoredApps.Shared.ExceptionHandling.csproj
+++ b/src/TailoredApps.Shared.ExceptionHandling/TailoredApps.Shared.ExceptionHandling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	  <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
       <AssemblyName>TailoredApps.Shared.ExceptionHandling</AssemblyName>
       <RootNamespace>TailoredApps.Shared.ExceptionHandling</RootNamespace>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/TailoredApps.Shared.MediatR.Caching/TailoredApps.Shared.MediatR.Caching.csproj
+++ b/src/TailoredApps.Shared.MediatR.Caching/TailoredApps.Shared.MediatR.Caching.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="12.0.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/TailoredApps.Shared.MediatR.Email/TailoredApps.Shared.MediatR.Email.csproj
+++ b/src/TailoredApps.Shared.MediatR.Email/TailoredApps.Shared.MediatR.Email.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
@@ -12,7 +12,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="12.0.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TailoredApps.Shared.MediatR.ML/TailoredApps.Shared.MediatR.ML.csproj
+++ b/src/TailoredApps.Shared.MediatR.ML/TailoredApps.Shared.MediatR.ML.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
@@ -12,11 +12,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.ML" Version="2.0.1" />
-		<PackageReference Include="Microsoft.ML" Version="2.0.1" />
-		<PackageReference Include="Microsoft.ML.ImageAnalytics" Version="2.0.1" />
-		<PackageReference Include="Microsoft.ML.Vision" Version="2.0.1" />
-		<PackageReference Include="Microsoft.ML.AutoML" Version="0.20.1" />
+		<PackageReference Include="Microsoft.Extensions.ML" Version="5.0.0" />
+		<PackageReference Include="Microsoft.ML" Version="5.0.0" />
+		<PackageReference Include="Microsoft.ML.ImageAnalytics" Version="5.0.0" />
+		<PackageReference Include="Microsoft.ML.Vision" Version="5.0.0" />
+		<PackageReference Include="Microsoft.ML.AutoML" Version="0.23.0" />
 		<PackageReference Include="FluentValidation" Version="12.*" />
 	</ItemGroup>
 
@@ -25,15 +25,20 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net8.0'" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.*" Condition="'$(TargetFramework)' == 'net8.0'" />
 
 		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.*" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" Condition="'$(TargetFramework)' == 'net7.0'" />

--- a/src/TailoredApps.Shared.MediatR.PagedRequest/TailoredApps.Shared.MediatR.PagedRequest.csproj
+++ b/src/TailoredApps.Shared.MediatR.PagedRequest/TailoredApps.Shared.MediatR.PagedRequest.csproj
@@ -2,13 +2,13 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MediatR" Version="12.0.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TailoredApps.Shared.MediatR/TailoredApps.Shared.MediatR.csproj
+++ b/src/TailoredApps.Shared.MediatR/TailoredApps.Shared.MediatR.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<AssemblyName>TailoredApps.Shared.MediatR</AssemblyName>
 		<RootNamespace>TailoredApps.Shared.MediatR</RootNamespace>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -26,10 +26,17 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" Version="12.*" />
-		<PackageReference Include="MediatR" Version="12.0.1" />
+		<PackageReference Include="MediatR" Version="12.5.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.*" />
 		<PackageReference Include="Polly" Version="8.*" />
-		<PackageReference Include="Scrutor" Version="6.1.0" />
+		<PackageReference Include="Scrutor" Version="7.0.0" />
+
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
 
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.*" Condition="'$(TargetFramework)' == 'net9.0'" />

--- a/src/TailoredApps.Shared.Payments.Provider.CashBill/TailoredApps.Shared.Payments.Provider.CashBill.csproj
+++ b/src/TailoredApps.Shared.Payments.Provider.CashBill/TailoredApps.Shared.Payments.Provider.CashBill.csproj
@@ -2,11 +2,17 @@
 
   <PropertyGroup>
 	  <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	  <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>
 		<PackageReference Include="Microsoft.Extensions.Options" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>

--- a/src/TailoredApps.Shared.Payments/TailoredApps.Shared.Payments.csproj
+++ b/src/TailoredApps.Shared.Payments/TailoredApps.Shared.Payments.csproj
@@ -2,11 +2,14 @@
 
 	<PropertyGroup>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Primitives" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
+
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>
 		<PackageReference Include="Microsoft.Extensions.Primitives" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>
 

--- a/tests/TailoredApps.Shared.DateTime.Tests/TailoredApps.Shared.DateTime.Tests.csproj
+++ b/tests/TailoredApps.Shared.DateTime.Tests/TailoredApps.Shared.DateTime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/tests/TailoredApps.Shared.Email.Tests/TailoredApps.Shared.Email.Tests.csproj
+++ b/tests/TailoredApps.Shared.Email.Tests/TailoredApps.Shared.Email.Tests.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0"  />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.*"  />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.*" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
 
 
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />

--- a/tests/TailoredApps.Shared.EntityFramework.Tests/TailoredApps.Shared.EntityFramework.Tests.csproj
+++ b/tests/TailoredApps.Shared.EntityFramework.Tests/TailoredApps.Shared.EntityFramework.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.*" />
 		<PackageReference Include="AutoMoqCore" Version="2.*" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
 		<PackageReference Include="xunit" Version="2.*" />

--- a/tests/TailoredApps.Shared.MediatR.ML.Tests/TailoredApps.Shared.MediatR.ML.Tests.csproj
+++ b/tests/TailoredApps.Shared.MediatR.ML.Tests/TailoredApps.Shared.MediatR.ML.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="SciSharp.TensorFlow.Redist" Version="2.3.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.*" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.*" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
 		<PackageReference Include="xunit" Version="2.*" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.*">

--- a/tests/TailoredApps.Shared.Payments.Tests/TailoredApps.Shared.Payments.Tests.csproj
+++ b/tests/TailoredApps.Shared.Payments.Tests/TailoredApps.Shared.Payments.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net9.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'"/>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.*"  Condition="'$(TargetFramework)' == 'net10.0'"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
 		<PackageReference Include="xunit" Version="2.*" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.*">


### PR DESCRIPTION
This commit adds multi-targeting support for .NET 10 across all library and test projects, and updates critical packages to address security vulnerabilities and maintain open-source licensing.

## .NET 10 Multi-Targeting
- Updated 12 library projects to target net8.0, net9.0, and net10.0
- Added framework-specific package references with version aliases (10.* for .NET 10)
- Updated 5 test projects to target net10.0
- All projects build successfully across all target frameworks

## Package Updates

### MediatR (12.0.1 → 12.5.0)
- Updated to last Apache-2.0 licensed version before commercial transition
- Updated in: MediatR, MediatR.Caching, MediatR.Email, MediatR.PagedRequest
- Maintains open-source licensing for project sustainability

### Microsoft.ML Packages (Security Fix)
- Fixed high severity SkiaSharp vulnerability (GHSA-j7hp-h8jx-5ppr)
- Microsoft.ML: 2.0.1 → 5.0.0
- Microsoft.ML.ImageAnalytics: 2.0.1 → 5.0.0
- Microsoft.ML.Vision: 2.0.1 → 5.0.0
- Microsoft.Extensions.ML: 2.0.1 → 5.0.0
- Microsoft.ML.AutoML: 0.20.1 → 0.23.0
- Updated Microsoft.Extensions.* references for net8.0 to 9.* to satisfy dependencies

### Scrutor (6.1.0 → 7.0.0)
- Updated to latest stable version in MediatR project

## Verification
- Build: Successful (0 errors, warnings pre-existing)
- Vulnerability Scan: All 20 projects now have NO vulnerable packages
- Tests: 39 total, 36 passed, 3 skipped (integration tests requiring manual setup), 0 failed