### PR TITLE
Update GitHub Actions workflows to latest versions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,10 +12,10 @@ jobs:
     name: Build and test
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setting up .NET Core SDK ${{ env.NETCORE_VERSION }}...
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.NETCORE_VERSION }}
 
@@ -32,6 +32,6 @@ jobs:
         run: dotnet test --no-build --configuration Release --no-restore --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat="opencover"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      -  uses: actions/setup-dotnet@v1
-         with:
-           dotnet-version: 9.0.x
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
       - name: Restore Workloads
         run: dotnet workload restore
       - name: Test
         run: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat="opencover"
           
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-          
-      - uses: actions/cache@v2
+
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -6,12 +6,12 @@ jobs:
     runs-on: windows-2022
     steps:
       # Checkout the code
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v4
+
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore Workloads
         run: dotnet workload restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,13 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
         # Install .NET Core SDK
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
 
     - name: Dotnet Pack 
       working-directory: .


### PR DESCRIPTION
Fixes deprecation warnings and updates to latest action versions:
- actions/cache: v2 → v4 (fixes deprecation warning)
- actions/checkout: v1/v2/v3 → v4
- actions/setup-dotnet: v1 → v4
- actions/setup-python: v4 → v5
- codecov/codecov-action: v3 → v5
- .NET SDK: 9.0.x → 10.0.x in remaining workflows

This resolves the "actions/cache v2 is deprecated" error and ensures all workflows use the latest, most secure action versions with improved performance.