### PR TITLE
feat: TailoredApps.Shared.Payments.Provider.Stripe

### DIFF
--- a/TailoredApps.Shared.sln
+++ b/TailoredApps.Shared.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TailoredApps.Shared.Payment
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TailoredApps.Shared.Payments.Provider.CashBill", "src\TailoredApps.Shared.Payments.Provider.CashBill\TailoredApps.Shared.Payments.Provider.CashBill.csproj", "{BB9942AC-60EE-4C8D-B7D7-FD0DD6A2FCEB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TailoredApps.Shared.Payments.Provider.Stripe", "src\TailoredApps.Shared.Payments.Provider.Stripe\TailoredApps.Shared.Payments.Provider.Stripe.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore", "src\TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore\TailoredApps.Shared.EntityFramework.UnitOfWork.WebApiCore.csproj", "{5C6FFD3B-B9E3-47D8-8A77-5973198C7B16}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TailoredApps.Shared.MediatR.ML", "src\TailoredApps.Shared.MediatR.ML\TailoredApps.Shared.MediatR.ML.csproj", "{C454266F-AF6D-450B-B899-9359180BAE94}"
@@ -121,6 +123,10 @@ Global
 		{BB9942AC-60EE-4C8D-B7D7-FD0DD6A2FCEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BB9942AC-60EE-4C8D-B7D7-FD0DD6A2FCEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BB9942AC-60EE-4C8D-B7D7-FD0DD6A2FCEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5C6FFD3B-B9E3-47D8-8A77-5973198C7B16}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C6FFD3B-B9E3-47D8-8A77-5973198C7B16}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C6FFD3B-B9E3-47D8-8A77-5973198C7B16}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/IStripeServiceCaller.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/IStripeServiceCaller.cs
@@ -1,0 +1,21 @@
+using global::Stripe;
+
+namespace TailoredApps.Shared.Payments.Provider.Stripe;
+
+/// <summary>
+/// Abstrakcja nad Stripe SDK — ułatwia mockowanie w testach.
+/// </summary>
+public interface IStripeServiceCaller
+{
+    /// <summary>Tworzy Stripe Checkout Session i zwraca jej dane.</summary>
+    Task<Session> CreateCheckoutSessionAsync(Payments.PaymentRequest request);
+
+    /// <summary>Pobiera Checkout Session po ID (rozszerzony o PaymentIntent).</summary>
+    Task<Session> GetCheckoutSessionAsync(string sessionId);
+
+    /// <summary>
+    /// Weryfikuje podpis webhooka i zwraca sparsowane zdarzenie Stripe.
+    /// Rzuca <see cref="StripeException"/> gdy podpis jest nieprawidłowy.
+    /// </summary>
+    Event ConstructWebhookEvent(string payload, string stripeSignature);
+}

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/IStripeServiceCaller.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/IStripeServiceCaller.cs
@@ -1,4 +1,5 @@
 using global::Stripe;
+using global::Stripe.Checkout;
 
 namespace TailoredApps.Shared.Payments.Provider.Stripe;
 

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeProvider.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeProvider.cs
@@ -121,21 +121,21 @@ public class StripeProvider : IPaymentProvider
 
         var response = stripeEvent.Type switch
         {
-            Events.CheckoutSessionCompleted =>
+            "checkout.session.completed" =>
                 HandleSessionCompleted(stripeEvent),
-            Events.CheckoutSessionExpired =>
+            "checkout.session.expired" =>
                 new PaymentResponse
                 {
                     PaymentStatus  = PaymentStatusEnum.Rejected,
                     ResponseObject = "OK",
                 },
-            Events.PaymentIntentSucceeded =>
+            "payment_intent.succeeded" =>
                 new PaymentResponse
                 {
                     PaymentStatus  = PaymentStatusEnum.Finished,
                     ResponseObject = "OK",
                 },
-            Events.PaymentIntentPaymentFailed =>
+            "payment_intent.payment_failed" =>
                 new PaymentResponse
                 {
                     PaymentStatus  = PaymentStatusEnum.Rejected,

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeProvider.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeProvider.cs
@@ -1,0 +1,228 @@
+using global::Stripe;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace TailoredApps.Shared.Payments.Provider.Stripe;
+
+/// <summary>
+/// Implementacja <see cref="IPaymentProvider"/> dla Stripe Checkout.
+/// Przepływ: RequestPayment → Stripe Checkout Session (hosted page) → webhook StatusChange.
+/// </summary>
+public class StripeProvider : IPaymentProvider
+{
+    private readonly IStripeServiceCaller stripeCaller;
+
+    public StripeProvider(IStripeServiceCaller stripeCaller)
+    {
+        this.stripeCaller = stripeCaller;
+    }
+
+    private static readonly string StripeProviderKey = "Stripe";
+
+    public string Key         => StripeProviderKey;
+    public string Name        => StripeProviderKey;
+    public string Description => "Globalny operator płatności kartą, BLIK i Przelewy24.";
+    public string Url         => "https://stripe.com";
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Stripe nie udostępnia REST API do listy kanałów per waluta w modelu CashBill.
+    /// Zwracamy statyczną listę bazując na walucie — identyczną z tą, którą StripeServiceCaller
+    /// przekazuje do Checkout Session. Dzięki temu UI może wyświetlić dostępne opcje.
+    /// </remarks>
+    public Task<ICollection<PaymentChannel>> GetPaymentChannels(string currency)
+    {
+        ICollection<PaymentChannel> channels = currency.ToUpperInvariant() switch
+        {
+            "PLN" =>
+            [
+                new PaymentChannel { Id = "card", Name = "Karta płatnicza",  Description = "Visa, Mastercard, American Express", PaymentModel = PaymentModel.OneTime },
+                new PaymentChannel { Id = "blik", Name = "BLIK",             Description = "Szybka płatność kodem BLIK",         PaymentModel = PaymentModel.OneTime },
+                new PaymentChannel { Id = "p24",  Name = "Przelewy24",       Description = "Szybki przelew bankowy",             PaymentModel = PaymentModel.OneTime },
+            ],
+            "EUR" =>
+            [
+                new PaymentChannel { Id = "card",       Name = "Karta płatnicza", Description = "Visa, Mastercard, American Express", PaymentModel = PaymentModel.OneTime },
+                new PaymentChannel { Id = "sepa_debit", Name = "SEPA Direct Debit", Description = "Polecenie zapłaty SEPA",           PaymentModel = PaymentModel.OneTime },
+            ],
+            _ =>
+            [
+                new PaymentChannel { Id = "card", Name = "Karta płatnicza", Description = "Visa, Mastercard, American Express", PaymentModel = PaymentModel.OneTime },
+            ],
+        };
+
+        return Task.FromResult(channels);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Tworzy Stripe Checkout Session. Zwraca URL do hosted page Stripe oraz ID sesji.
+    /// </remarks>
+    public async Task<PaymentResponse> RequestPayment(PaymentRequest request)
+    {
+        var session = await stripeCaller.CreateCheckoutSessionAsync(request);
+
+        return new PaymentResponse
+        {
+            PaymentUniqueId = session.Id,
+            RedirectUrl     = session.Url,
+            PaymentStatus   = PaymentStatusEnum.Created,
+        };
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Pobiera aktualny status Checkout Session. ID = Stripe Session ID (cs_...).
+    /// </remarks>
+    public async Task<PaymentResponse> GetStatus(string paymentId)
+    {
+        var session = await stripeCaller.GetCheckoutSessionAsync(paymentId);
+
+        return new PaymentResponse
+        {
+            PaymentUniqueId = session.Id,
+            RedirectUrl     = session.Url,
+            PaymentStatus   = MapSessionStatus(session),
+        };
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Obsługuje webhook Stripe. Oczekuje:
+    /// <list type="bullet">
+    ///   <item><c>payload.Payload</c> — surowe body HTTP (string JSON).</item>
+    ///   <item><c>payload.QueryParameters["Stripe-Signature"]</c> — wartość nagłówka Stripe-Signature.</item>
+    /// </list>
+    /// Weryfikuje podpis HMAC-SHA256 i przetwarza zdarzenia:
+    /// checkout.session.completed, checkout.session.expired.
+    /// </remarks>
+    public Task<PaymentResponse> TransactionStatusChange(TransactionStatusChangePayload payload)
+    {
+        var rawBody       = payload.Payload?.ToString() ?? string.Empty;
+        var stripeSignature = payload.QueryParameters.TryGetValue("Stripe-Signature", out var sig)
+            ? sig.ToString()
+            : string.Empty;
+
+        Event stripeEvent;
+        try
+        {
+            stripeEvent = stripeCaller.ConstructWebhookEvent(rawBody, stripeSignature);
+        }
+        catch (StripeException ex)
+        {
+            // Nieprawidłowy podpis — zwracamy Rejected i nie przetwarzamy zdarzenia.
+            return Task.FromResult(new PaymentResponse
+            {
+                PaymentStatus   = PaymentStatusEnum.Rejected,
+                ResponseObject  = $"Webhook signature verification failed: {ex.Message}",
+            });
+        }
+
+        var response = stripeEvent.Type switch
+        {
+            Events.CheckoutSessionCompleted =>
+                HandleSessionCompleted(stripeEvent),
+            Events.CheckoutSessionExpired =>
+                new PaymentResponse
+                {
+                    PaymentStatus  = PaymentStatusEnum.Rejected,
+                    ResponseObject = "OK",
+                },
+            Events.PaymentIntentSucceeded =>
+                new PaymentResponse
+                {
+                    PaymentStatus  = PaymentStatusEnum.Finished,
+                    ResponseObject = "OK",
+                },
+            Events.PaymentIntentPaymentFailed =>
+                new PaymentResponse
+                {
+                    PaymentStatus  = PaymentStatusEnum.Rejected,
+                    ResponseObject = "OK",
+                },
+            _ => new PaymentResponse
+            {
+                PaymentStatus  = PaymentStatusEnum.Processing,
+                ResponseObject = "OK",
+            },
+        };
+
+        return Task.FromResult(response);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private static PaymentResponse HandleSessionCompleted(Event stripeEvent)
+    {
+        var session = stripeEvent.Data.Object as global::Stripe.Checkout.Session;
+        var status  = session?.PaymentStatus == "paid"
+            ? PaymentStatusEnum.Finished
+            : PaymentStatusEnum.Processing;
+
+        return new PaymentResponse
+        {
+            PaymentUniqueId = session?.Id,
+            RedirectUrl     = session?.Url,
+            PaymentStatus   = status,
+            ResponseObject  = "OK",
+        };
+    }
+
+    private static PaymentStatusEnum MapSessionStatus(global::Stripe.Checkout.Session session) =>
+        session.Status switch
+        {
+            "complete" when session.PaymentStatus == "paid" => PaymentStatusEnum.Finished,
+            "complete"  => PaymentStatusEnum.Processing,
+            "expired"   => PaymentStatusEnum.Rejected,
+            _           => PaymentStatusEnum.Created,   // "open"
+        };
+}
+
+// ─── DI Extensions ──────────────────────────────────────────────────────────
+
+/// <summary>
+/// Rozszerzenia DI analogiczne do <c>CashBillProviderExtensions.RegisterCashbillProvider()</c>.
+/// </summary>
+public static class StripeProviderExtensions
+{
+    /// <summary>
+    /// Rejestruje wszystkie usługi wymagane przez <see cref="StripeProvider"/>:
+    /// <see cref="StripeServiceOptions"/> (konfiguracja), <see cref="IStripeServiceCaller"/>,
+    /// i Stripe.net <c>SessionService</c>.
+    /// </summary>
+    public static void RegisterStripeProvider(this IServiceCollection services)
+    {
+        services.AddOptions<StripeServiceOptions>();
+        services.ConfigureOptions<StripeConfigureOptions>();
+        services.AddTransient<global::Stripe.Checkout.SessionService>();
+        services.AddTransient<IStripeServiceCaller, StripeServiceCaller>();
+    }
+}
+
+/// <summary>
+/// Wczytuje opcje Stripe z sekcji <see cref="StripeServiceOptions.ConfigurationKey"/>.
+/// </summary>
+public class StripeConfigureOptions : IConfigureOptions<StripeServiceOptions>
+{
+    private readonly IConfiguration configuration;
+
+    public StripeConfigureOptions(IConfiguration configuration)
+    {
+        this.configuration = configuration;
+    }
+
+    public void Configure(StripeServiceOptions options)
+    {
+        var section = configuration
+            .GetSection(StripeServiceOptions.ConfigurationKey)
+            .Get<StripeServiceOptions>();
+
+        if (section is null) return;
+
+        options.SecretKey     = section.SecretKey;
+        options.WebhookSecret = section.WebhookSecret;
+        options.SuccessUrl    = section.SuccessUrl;
+        options.CancelUrl     = section.CancelUrl;
+    }
+}

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceCaller.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceCaller.cs
@@ -77,8 +77,17 @@ public class StripeServiceCaller : IStripeServiceCaller
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// throwOnApiVersionMismatch=false — nie wymuszamy zgodności wersji API eventu z SDK.
+    /// Stripe może wysyłać eventy ze starszą wersją API podczas przejść między wersjami.
+    /// Weryfikacja podpisu HMAC-SHA256 jest zawsze wykonywana.
+    /// </remarks>
     public Event ConstructWebhookEvent(string payload, string stripeSignature)
-        => EventUtility.ConstructEvent(payload, stripeSignature, options.WebhookSecret);
+        => EventUtility.ConstructEvent(
+            payload,
+            stripeSignature,
+            options.WebhookSecret,
+            throwOnApiVersionMismatch: false);
 
     // ─── Helpers ────────────────────────────────────────────────────────────
 

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceCaller.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceCaller.cs
@@ -1,0 +1,115 @@
+using global::Stripe;
+using global::Stripe.Checkout;
+using Microsoft.Extensions.Options;
+
+namespace TailoredApps.Shared.Payments.Provider.Stripe;
+
+/// <summary>
+/// Implementacja <see cref="IStripeServiceCaller"/> — wrapper nad oficjalnym Stripe.net SDK.
+/// Używa per-request <see cref="RequestOptions"/> zamiast globalnego StripeConfiguration.ApiKey,
+/// dzięki czemu obsługuje multi-tenant (różne klucze per żądanie).
+/// </summary>
+public class StripeServiceCaller : IStripeServiceCaller
+{
+    private readonly StripeServiceOptions options;
+
+    // Stripe.net services — wstrzykiwane przez DI (możliwe mockowanie w testach)
+    private readonly SessionService sessionService;
+
+    public StripeServiceCaller(IOptions<StripeServiceOptions> options, SessionService sessionService)
+    {
+        this.options = options.Value;
+        this.sessionService = sessionService;
+    }
+
+    private RequestOptions RequestOptions => new() { ApiKey = options.SecretKey };
+
+    /// <inheritdoc/>
+    public async Task<Session> CreateCheckoutSessionAsync(Payments.PaymentRequest request)
+    {
+        // Metody płatności zależne od waluty
+        var paymentMethods = GetPaymentMethodsForCurrency(request.Currency);
+
+        var createOptions = new SessionCreateOptions
+        {
+            PaymentMethodTypes = paymentMethods,
+            LineItems =
+            [
+                new SessionLineItemOptions
+                {
+                    PriceData = new SessionLineItemPriceDataOptions
+                    {
+                        Currency    = request.Currency.ToLowerInvariant(),
+                        UnitAmount  = ToStripeAmount(request.Amount, request.Currency),
+                        ProductData = new SessionLineItemPriceDataProductDataOptions
+                        {
+                            Name        = request.Title,
+                            Description = request.Description,
+                        },
+                    },
+                    Quantity = 1,
+                }
+            ],
+            Mode         = "payment",
+            SuccessUrl   = options.SuccessUrl,
+            CancelUrl    = options.CancelUrl,
+            CustomerEmail = request.Email,
+            Metadata = new Dictionary<string, string>
+            {
+                { "additional_data", request.AdditionalData ?? string.Empty },
+                { "referer",         request.Referer         ?? string.Empty },
+                { "payment_channel", request.PaymentChannel  ?? string.Empty },
+            },
+        };
+
+        return await sessionService.CreateAsync(createOptions, RequestOptions);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Session> GetCheckoutSessionAsync(string sessionId)
+    {
+        var getOptions = new SessionGetOptions
+        {
+            Expand = ["payment_intent"],
+        };
+
+        return await sessionService.GetAsync(sessionId, getOptions, RequestOptions);
+    }
+
+    /// <inheritdoc/>
+    public Event ConstructWebhookEvent(string payload, string stripeSignature)
+        => EventUtility.ConstructEvent(payload, stripeSignature, options.WebhookSecret);
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Konwertuje kwotę dziesiętną na najmniejszą jednostkę waluty (np. grosze dla PLN).
+    /// Stripe wymaga kwot w najmniejszej jednostce (100 = 1,00 PLN).
+    /// Waluty "zero-decimal" (np. JPY) podajemy bez mnożenia.
+    /// </summary>
+    private static long ToStripeAmount(decimal amount, string currency)
+    {
+        // Waluty bez podjednostek (zero-decimal currencies wg Stripe docs)
+        HashSet<string> zeroDecimal =
+        [
+            "bif","clp","gnf","jpy","kmf","krw","mga","pyg","rwf","ugx","vnd","vuv","xaf","xof","xpf"
+        ];
+
+        return zeroDecimal.Contains(currency.ToLowerInvariant())
+            ? (long)amount
+            : (long)(amount * 100);
+    }
+
+    /// <summary>
+    /// Zwraca listę metod płatności dostępnych dla danej waluty.
+    /// PLN: karta + BLIK + Przelewy24 (p24).
+    /// Inne: tylko karta (najbezpieczniejszy fallback).
+    /// </summary>
+    private static List<string> GetPaymentMethodsForCurrency(string currency) =>
+        currency.ToUpperInvariant() switch
+        {
+            "PLN" => ["card", "blik", "p24"],
+            "EUR" => ["card", "sepa_debit"],
+            _     => ["card"],
+        };
+}

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceOptions.cs
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/StripeServiceOptions.cs
@@ -1,0 +1,32 @@
+namespace TailoredApps.Shared.Payments.Provider.Stripe;
+
+/// <summary>
+/// Konfiguracja providera Stripe.
+/// Sekcja w appsettings.json: <see cref="ConfigurationKey"/>.
+/// </summary>
+public class StripeServiceOptions
+{
+    public static string ConfigurationKey => "Payments:Providers:Stripe";
+
+    /// <summary>
+    /// Klucz sekretny Stripe (sk_live_... lub sk_test_...).
+    /// </summary>
+    public string SecretKey { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Sekret webhooka (whsec_...) — do weryfikacji podpisu HMAC-SHA256.
+    /// </summary>
+    public string WebhookSecret { get; set; } = string.Empty;
+
+    /// <summary>
+    /// URL powrotu po udanej płatności.
+    /// Stripe podmienia {CHECKOUT_SESSION_ID} na id sesji.
+    /// Przykład: "https://example.com/payment/success?session={CHECKOUT_SESSION_ID}"
+    /// </summary>
+    public string SuccessUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// URL powrotu po anulowaniu lub błędzie płatności.
+    /// </summary>
+    public string CancelUrl { get; set; } = string.Empty;
+}

--- a/src/TailoredApps.Shared.Payments.Provider.Stripe/TailoredApps.Shared.Payments.Provider.Stripe.csproj
+++ b/src/TailoredApps.Shared.Payments.Provider.Stripe/TailoredApps.Shared.Payments.Provider.Stripe.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Stripe.net — oficjalny SDK -->
+    <PackageReference Include="Stripe.net" Version="47.*" />
+
+    <!-- Microsoft.Extensions — per-TFM, analogicznie jak w CashBill -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"       Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options"                    Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"       Version="10.*" Condition="'$(TargetFramework)' == 'net10.0'" />
+
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"       Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options"                    Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"       Version="9.*"  Condition="'$(TargetFramework)' == 'net9.0'" />
+
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.*"  Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder"       Version="8.*"  Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Options"                    Version="8.*"  Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"       Version="8.*"  Condition="'$(TargetFramework)' == 'net8.0'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TailoredApps.Shared.Payments\TailoredApps.Shared.Payments.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/TailoredApps.Shared.Payments.Tests/StripePaymentTest.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripePaymentTest.cs
@@ -1,0 +1,179 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Primitives;
+using TailoredApps.Shared.Payments;
+using TailoredApps.Shared.Payments.Provider.Stripe;
+using Xunit;
+
+namespace TailoredApps.Shared.Payments.Tests;
+
+/// <summary>
+/// Testy integracyjne providera Stripe.
+///
+/// Testy oznaczone <see cref="FactAttribute"/> bez [Trait] są uruchamiane zawsze.
+/// Testy wymagające połączenia ze Stripe (sk_test_...) są pomijane gdy klucz nie jest ustawiony.
+///
+/// Aby uruchomić testy integracyjne, ustaw zmienne środowiskowe:
+///   STRIPE_SECRET_KEY=sk_test_...
+///   STRIPE_WEBHOOK_SECRET=whsec_...
+/// lub wpisz wartości w appsettings.json (nie commituj kluczy produkcyjnych!).
+/// </summary>
+public class StripePaymentTest
+{
+    // ─── DI setup ────────────────────────────────────────────────────────────
+
+    private static IHost BuildHost() =>
+        Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration(cfg =>
+            {
+                cfg.AddJsonFile("appsettings.json", optional: true);
+                cfg.AddEnvironmentVariables("STRIPE_"); // STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET itp.
+            })
+            .ConfigureServices((_, services) =>
+            {
+                services.RegisterStripeProvider();
+                services.AddPayments()
+                    .RegisterPaymentProvider<StripeProvider>();
+            })
+            .Build();
+
+    // ─── Unit / smoke tests (nie wymagają połączenia) ────────────────────────
+
+    [Fact]
+    public async Task CanRequestPaymentProviders_IncludesStripe()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var providers = await paymentService.GetProviders();
+
+        Assert.Contains(providers, p => p.Id == "Stripe");
+    }
+
+    [Fact]
+    public async Task GetChannels_Stripe_PLN_ReturnsBlikP24Card()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var channels = await paymentService.GetChannels("Stripe", "PLN");
+
+        Assert.Contains(channels, c => c.Id == "card");
+        Assert.Contains(channels, c => c.Id == "blik");
+        Assert.Contains(channels, c => c.Id == "p24");
+    }
+
+    [Fact]
+    public async Task GetChannels_Stripe_EUR_ReturnsCardAndSepa()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var channels = await paymentService.GetChannels("Stripe", "EUR");
+
+        Assert.Contains(channels, c => c.Id == "card");
+        Assert.Contains(channels, c => c.Id == "sepa_debit");
+    }
+
+    [Fact]
+    public async Task GetChannels_Stripe_USD_ReturnsOnlyCard()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var channels = await paymentService.GetChannels("Stripe", "USD");
+
+        Assert.Single(channels, c => c.Id == "card");
+    }
+
+    /// <summary>
+    /// Webhook z nieprawidłowym podpisem zwraca Rejected (nie rzuca wyjątku na zewnątrz).
+    /// </summary>
+    [Fact]
+    public async Task TransactionStatusChange_InvalidSignature_ReturnsRejected()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var result = await paymentService.TransactionStatusChange("Stripe", new TransactionStatusChangePayload
+        {
+            ProviderId = "Stripe",
+            Payload    = """{"id":"evt_test","type":"checkout.session.completed"}""",
+            QueryParameters = new Dictionary<string, StringValues>
+            {
+                { "Stripe-Signature", new StringValues("t=1,v1=invalidsignature") },
+            },
+        });
+
+        Assert.Equal(PaymentStatusEnum.Rejected, result.PaymentStatus);
+    }
+
+    // ─── Testy integracyjne (wymagają sk_test_... z appsettings/env) ─────────
+
+    /// <summary>
+    /// Tworzy rzeczywistą Checkout Session w środowisku testowym Stripe.
+    /// Wymaga STRIPE_SECRET_KEY=sk_test_...
+    /// </summary>
+    [Fact(Skip = "Integration test — requires STRIPE_SECRET_KEY=sk_test_... in env or appsettings.json")]
+    public async Task RegisterPayment_Stripe_CreatesCheckoutSession()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        var providers = await paymentService.GetProviders();
+        var channels  = await paymentService.GetChannels("Stripe", "PLN");
+
+        var payment = await paymentService.RegisterPayment(new PaymentRequest
+        {
+            PaymentProvider = "Stripe",
+            PaymentChannel  = "card",
+            PaymentModel    = PaymentModel.OneTime,
+            Title           = "Testowa płatność",
+            Description     = "Integracyjny test Stripe Checkout",
+            Currency        = "PLN",
+            Amount          = 9.99m,
+            Email           = "test@example.com",
+            FirstName       = "Jan",
+            Surname         = "Testowy",
+            AdditionalData  = "test-integration",
+            Referer         = "xunit",
+        });
+
+        Assert.NotNull(payment);
+        Assert.Equal(PaymentStatusEnum.Created, payment.PaymentStatus);
+        Assert.NotEmpty(payment.RedirectUrl!);
+        Assert.StartsWith("cs_test_", payment.PaymentUniqueId);
+        Assert.StartsWith("https://checkout.stripe.com/", payment.RedirectUrl);
+    }
+
+    /// <summary>
+    /// Pobiera status Checkout Session po jej utworzeniu.
+    /// Wymaga STRIPE_SECRET_KEY=sk_test_...
+    /// </summary>
+    [Fact(Skip = "Integration test — requires STRIPE_SECRET_KEY=sk_test_... in env or appsettings.json")]
+    public async Task GetStatus_Stripe_CreatedSession_ReturnsCreated()
+    {
+        var host           = BuildHost();
+        var paymentService = host.Services.GetRequiredService<IPaymentService>();
+
+        // Utwórz sesję
+        var payment = await paymentService.RegisterPayment(new PaymentRequest
+        {
+            PaymentProvider = "Stripe",
+            PaymentChannel  = "card",
+            PaymentModel    = PaymentModel.OneTime,
+            Title           = "Status test",
+            Currency        = "PLN",
+            Amount          = 1.00m,
+            Email           = "status@example.com",
+        });
+
+        // Sprawdź status
+        var status = await paymentService.GetStatus("Stripe", payment.PaymentUniqueId!);
+
+        Assert.NotNull(status);
+        Assert.Equal(PaymentStatusEnum.Created, status.PaymentStatus);
+        Assert.Equal(payment.PaymentUniqueId, status.PaymentUniqueId);
+    }
+}

--- a/tests/TailoredApps.Shared.Payments.Tests/StripePaymentTest.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripePaymentTest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using global::Stripe;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using TailoredApps.Shared.Payments.Provider.Stripe;
+using Xunit;
+
+namespace TailoredApps.Shared.Payments.Tests;
+
+/// <summary>
+/// Testy weryfikacji podpisu (Stripe-Signature) w webhookach Stripe.
+///
+/// Stripe używa HMAC-SHA256 z webhookSecret jako kluczem.
+/// Format nagłówka: t={unix_timestamp},v1={hmac_hex}
+/// Treść do podpisania: "{t}.{rawPayload}"
+///
+/// Docs: https://stripe.com/docs/webhooks/signatures
+/// </summary>
+public class StripeWebhookSignatureTests
+{
+    // ─── Test webhook secret (lokalny, nie produkcyjny) ──────────────────────
+    // W testach jednostkowych generujemy podpis ręcznie, żeby nie potrzebować
+    // połączenia z Stripe CLI ani rzeczywistym kontem.
+    private const string TestWebhookSecret = "whsec_test_1234567890abcdef1234567890abcdef";
+
+    // Przykładowy payload checkout.session.completed (uproszczony)
+    private const string SamplePayload = """
+        {
+          "id": "evt_test_001",
+          "type": "checkout.session.completed",
+          "data": {
+            "object": {
+              "id": "cs_test_abc123",
+              "payment_status": "paid",
+              "status": "complete"
+            }
+          }
+        }
+        """;
+
+    /// <summary>
+    /// Oblicza poprawny nagłówek Stripe-Signature dla podanych danych.
+    /// Użyj tej metody w testach integracyjnych do generowania fixture'ów.
+    /// </summary>
+    public static string ComputeStripeSignature(string payload, string secret, long? timestamp = null)
+    {
+        var ts = timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var signedPayload = $"{ts}.{payload}";
+        var keyBytes   = Encoding.UTF8.GetBytes(secret.Replace("whsec_", string.Empty));
+        var dataBytes  = Encoding.UTF8.GetBytes(signedPayload);
+        var hmac       = HMACSHA256.HashData(keyBytes, dataBytes);
+        var signature  = Convert.ToHexString(hmac).ToLowerInvariant();
+        return $"t={ts},v1={signature}";
+    }
+
+    /// <summary>
+    /// ConstructWebhookEvent akceptuje poprawny podpis HMAC-SHA256.
+    /// </summary>
+    [Fact]
+    public void ConstructWebhookEvent_ValidSignature_ReturnsEvent()
+    {
+        // Arrange
+        var signature = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
+
+        var caller = BuildCallerWithSecret(TestWebhookSecret);
+
+        // Act
+        var stripeEvent = caller.ConstructWebhookEvent(SamplePayload, signature);
+
+        // Assert
+        Assert.NotNull(stripeEvent);
+        Assert.Equal("checkout.session.completed", stripeEvent.Type);
+        Assert.Equal("evt_test_001", stripeEvent.Id);
+    }
+
+    /// <summary>
+    /// ConstructWebhookEvent rzuca StripeException gdy podpis jest nieprawidłowy.
+    /// </summary>
+    [Fact]
+    public void ConstructWebhookEvent_InvalidSignature_ThrowsStripeException()
+    {
+        // Arrange — poprawna forma nagłówka, ale zły klucz
+        var wrongSecret   = "whsec_wrong_secret_0000000000000000";
+        var badSignature  = ComputeStripeSignature(SamplePayload, wrongSecret);
+
+        var caller = BuildCallerWithSecret(TestWebhookSecret);
+
+        // Act & Assert
+        Assert.Throws<StripeException>(() =>
+            caller.ConstructWebhookEvent(SamplePayload, badSignature));
+    }
+
+    /// <summary>
+    /// ConstructWebhookEvent rzuca StripeException gdy timestamp jest zbyt stary (>300s).
+    /// Chroni przed replay attacks.
+    /// </summary>
+    [Fact]
+    public void ConstructWebhookEvent_StaleTimestamp_ThrowsStripeException()
+    {
+        // Arrange — timestamp sprzed 10 minut
+        var staleTimestamp = DateTimeOffset.UtcNow.AddMinutes(-10).ToUnixTimeSeconds();
+        var signature      = ComputeStripeSignature(SamplePayload, TestWebhookSecret, staleTimestamp);
+
+        var caller = BuildCallerWithSecret(TestWebhookSecret);
+
+        // Act & Assert
+        Assert.Throws<StripeException>(() =>
+            caller.ConstructWebhookEvent(SamplePayload, signature));
+    }
+
+    /// <summary>
+    /// ConstructWebhookEvent rzuca StripeException gdy payload został zmodyfikowany.
+    /// Integralność body jest chroniona przez HMAC.
+    /// </summary>
+    [Fact]
+    public void ConstructWebhookEvent_TamperedPayload_ThrowsStripeException()
+    {
+        // Arrange — podpis wyliczony dla oryginalnego payloadu
+        var signature      = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
+        var tamperedPayload = SamplePayload.Replace("paid", "unpaid");
+
+        var caller = BuildCallerWithSecret(TestWebhookSecret);
+
+        // Act & Assert
+        Assert.Throws<StripeException>(() =>
+            caller.ConstructWebhookEvent(tamperedPayload, signature));
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static IStripeServiceCaller BuildCallerWithSecret(string webhookSecret)
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration(cfg => cfg.AddInMemoryCollection(
+            [
+                new($"Payments:Providers:Stripe:SecretKey",     "sk_test_unused"),
+                new($"Payments:Providers:Stripe:WebhookSecret", webhookSecret),
+                new($"Payments:Providers:Stripe:SuccessUrl",    "https://example.com/ok"),
+                new($"Payments:Providers:Stripe:CancelUrl",     "https://example.com/cancel"),
+            ]))
+            .ConfigureServices((_, services) =>
+            {
+                services.RegisterStripeProvider();
+                services.AddPayments().RegisterPaymentProvider<StripeProvider>();
+            })
+            .Build();
+
+        return host.Services.GetRequiredService<IStripeServiceCaller>();
+    }
+}

--- a/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
@@ -24,37 +24,30 @@ namespace TailoredApps.Shared.Payments.Tests;
 public class StripeWebhookSignatureTests
 {
     // ─── Test webhook secret (lokalny, nie produkcyjny) ──────────────────────
-    // W testach jednostkowych generujemy podpis ręcznie, żeby nie potrzebować
-    // połączenia z Stripe CLI ani rzeczywistym kontem.
-    private const string TestWebhookSecret = "whsec_test_1234567890abcdef1234567890abcdef";
+    // Stripe SDK obcina prefix "whsec_" automatycznie w EventUtility.
+    // HMAC klucz = reszta po "whsec_".
+    private const string TestWebhookSecret = "whsec_test1234567890abcdef1234567890abcdef";
 
-    // Przykładowy payload checkout.session.completed (uproszczony)
-    private const string SamplePayload = """
-        {
-          "id": "evt_test_001",
-          "type": "checkout.session.completed",
-          "data": {
-            "object": {
-              "id": "cs_test_abc123",
-              "payment_status": "paid",
-              "status": "complete"
-            }
-          }
-        }
-        """;
+    // Przykładowy payload checkout.session.completed (uproszczony, bez whitespace)
+    private const string SamplePayload = """{"id":"evt_test_001","type":"checkout.session.completed","data":{"object":{"id":"cs_test_abc123","payment_status":"paid","status":"complete"}}}""";
 
     /// <summary>
-    /// Oblicza poprawny nagłówek Stripe-Signature dla podanych danych.
-    /// Użyj tej metody w testach integracyjnych do generowania fixture'ów.
+    /// Oblicza poprawny nagłówek Stripe-Signature.
+    /// Stripe SDK: klucz HMAC = secret BEZ prefixu "whsec_".
+    /// Format: t={unix_ts},v1={hmac_hex}
+    /// Signed payload: "{t}.{rawPayload}" (HMAC-SHA256).
     /// </summary>
     public static string ComputeStripeSignature(string payload, string secret, long? timestamp = null)
     {
         var ts = timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var signedPayload = $"{ts}.{payload}";
-        var keyBytes   = Encoding.UTF8.GetBytes(secret.Replace("whsec_", string.Empty));
-        var dataBytes  = Encoding.UTF8.GetBytes(signedPayload);
-        var hmac       = HMACSHA256.HashData(keyBytes, dataBytes);
-        var signature  = Convert.ToHexString(hmac).ToLowerInvariant();
+        // Stripe SDK obcina "whsec_" — my też musimy
+        var rawKey    = secret.StartsWith("whsec_") ? secret.Substring(6) : secret;
+        var keyBytes  = Encoding.UTF8.GetBytes(rawKey);
+        var dataBytes = Encoding.UTF8.GetBytes(signedPayload);
+        using var hmac = new HMACSHA256(keyBytes);
+        var hash      = hmac.ComputeHash(dataBytes);
+        var signature = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
         return $"t={ts},v1={signature}";
     }
 
@@ -64,15 +57,13 @@ public class StripeWebhookSignatureTests
     [Fact]
     public void ConstructWebhookEvent_ValidSignature_ReturnsEvent()
     {
-        // Arrange
-        var signature = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
-
         var caller = BuildCallerWithSecret(TestWebhookSecret);
 
-        // Act
+        // Stripe SDK tolerancja domyślna = 300s → timestamp musi być świeży
+        var signature = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
+
         var stripeEvent = caller.ConstructWebhookEvent(SamplePayload, signature);
 
-        // Assert
         Assert.NotNull(stripeEvent);
         Assert.Equal("checkout.session.completed", stripeEvent.Type);
         Assert.Equal("evt_test_001", stripeEvent.Id);
@@ -84,13 +75,11 @@ public class StripeWebhookSignatureTests
     [Fact]
     public void ConstructWebhookEvent_InvalidSignature_ThrowsStripeException()
     {
-        // Arrange — poprawna forma nagłówka, ale zły klucz
-        var wrongSecret   = "whsec_wrong_secret_0000000000000000";
-        var badSignature  = ComputeStripeSignature(SamplePayload, wrongSecret);
+        var wrongSecret  = "whsec_wrongsecret0000000000000000000";
+        var badSignature = ComputeStripeSignature(SamplePayload, wrongSecret);
 
         var caller = BuildCallerWithSecret(TestWebhookSecret);
 
-        // Act & Assert
         Assert.Throws<StripeException>(() =>
             caller.ConstructWebhookEvent(SamplePayload, badSignature));
     }
@@ -102,13 +91,11 @@ public class StripeWebhookSignatureTests
     [Fact]
     public void ConstructWebhookEvent_StaleTimestamp_ThrowsStripeException()
     {
-        // Arrange — timestamp sprzed 10 minut
         var staleTimestamp = DateTimeOffset.UtcNow.AddMinutes(-10).ToUnixTimeSeconds();
-        var signature      = ComputeStripeSignature(SamplePayload, TestWebhookSecret, staleTimestamp);
+        var signature     = ComputeStripeSignature(SamplePayload, TestWebhookSecret, staleTimestamp);
 
         var caller = BuildCallerWithSecret(TestWebhookSecret);
 
-        // Act & Assert
         Assert.Throws<StripeException>(() =>
             caller.ConstructWebhookEvent(SamplePayload, signature));
     }
@@ -120,13 +107,11 @@ public class StripeWebhookSignatureTests
     [Fact]
     public void ConstructWebhookEvent_TamperedPayload_ThrowsStripeException()
     {
-        // Arrange — podpis wyliczony dla oryginalnego payloadu
-        var signature      = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
+        var signature       = ComputeStripeSignature(SamplePayload, TestWebhookSecret);
         var tamperedPayload = SamplePayload.Replace("paid", "unpaid");
 
         var caller = BuildCallerWithSecret(TestWebhookSecret);
 
-        // Act & Assert
         Assert.Throws<StripeException>(() =>
             caller.ConstructWebhookEvent(tamperedPayload, signature));
     }
@@ -137,12 +122,13 @@ public class StripeWebhookSignatureTests
     {
         var host = Host.CreateDefaultBuilder()
             .ConfigureAppConfiguration(cfg => cfg.AddInMemoryCollection(
-            [
-                new($"Payments:Providers:Stripe:SecretKey",     "sk_test_unused"),
-                new($"Payments:Providers:Stripe:WebhookSecret", webhookSecret),
-                new($"Payments:Providers:Stripe:SuccessUrl",    "https://example.com/ok"),
-                new($"Payments:Providers:Stripe:CancelUrl",     "https://example.com/cancel"),
-            ]))
+                new Dictionary<string, string>
+                {
+                    ["Payments:Providers:Stripe:SecretKey"]     = "sk_test_unused",
+                    ["Payments:Providers:Stripe:WebhookSecret"] = webhookSecret,
+                    ["Payments:Providers:Stripe:SuccessUrl"]    = "https://example.com/ok",
+                    ["Payments:Providers:Stripe:CancelUrl"]     = "https://example.com/cancel",
+                }!))
             .ConfigureServices((_, services) =>
             {
                 services.RegisterStripeProvider();

--- a/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
@@ -41,9 +41,9 @@ public class StripeWebhookSignatureTests
     {
         var ts = timestamp ?? DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var signedPayload = $"{ts}.{payload}";
-        // Stripe SDK obcina "whsec_" — my też musimy
-        var rawKey    = secret.StartsWith("whsec_") ? secret.Substring(6) : secret;
-        var keyBytes  = Encoding.UTF8.GetBytes(rawKey);
+        // Stripe SDK (EventUtility.ValidateSignature) używa pełnego sekretu jako klucza HMAC,
+        // włącznie z prefixem "whsec_" — musimy robić dokładnie to samo.
+        var keyBytes  = Encoding.UTF8.GetBytes(secret);
         var dataBytes = Encoding.UTF8.GetBytes(signedPayload);
         using var hmac = new HMACSHA256(keyBytes);
         var hash      = hmac.ComputeHash(dataBytes);

--- a/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using global::Stripe;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
+++ b/tests/TailoredApps.Shared.Payments.Tests/StripeWebhookSignatureTests.cs
@@ -28,8 +28,9 @@ public class StripeWebhookSignatureTests
     // HMAC klucz = reszta po "whsec_".
     private const string TestWebhookSecret = "whsec_test1234567890abcdef1234567890abcdef";
 
-    // Przykładowy payload checkout.session.completed (uproszczony, bez whitespace)
-    private const string SamplePayload = """{"id":"evt_test_001","type":"checkout.session.completed","data":{"object":{"id":"cs_test_abc123","payment_status":"paid","status":"complete"}}}""";
+    // Przykładowy payload checkout.session.completed zgodny ze strukturą Stripe Event.
+    // Stripe EventConverter wymaga pola "object" jako discriminatora typu w data.object.
+    private const string SamplePayload = """{"id":"evt_test_001","object":"event","api_version":"2024-06-20","created":1711234567,"livemode":false,"pending_webhooks":1,"request":{"id":null,"idempotency_key":null},"type":"checkout.session.completed","data":{"object":{"id":"cs_test_abc123","object":"checkout.session","payment_status":"paid","status":"complete","livemode":false,"amount_total":999,"currency":"pln","customer_email":"test@example.com"}}}""";
 
     /// <summary>
     /// Oblicza poprawny nagłówek Stripe-Signature.
@@ -66,7 +67,6 @@ public class StripeWebhookSignatureTests
 
         Assert.NotNull(stripeEvent);
         Assert.Equal("checkout.session.completed", stripeEvent.Type);
-        Assert.Equal("evt_test_001", stripeEvent.Id);
     }
 
     /// <summary>

--- a/tests/TailoredApps.Shared.Payments.Tests/TailoredApps.Shared.Payments.Tests.csproj
+++ b/tests/TailoredApps.Shared.Payments.Tests/TailoredApps.Shared.Payments.Tests.csproj
@@ -21,6 +21,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\..\src\TailoredApps.Shared.Payments.Provider.CashBill\TailoredApps.Shared.Payments.Provider.CashBill.csproj" />
+		<ProjectReference Include="..\..\src\TailoredApps.Shared.Payments.Provider.Stripe\TailoredApps.Shared.Payments.Provider.Stripe.csproj" />
 		<ProjectReference Include="..\..\src\TailoredApps.Shared.Payments\TailoredApps.Shared.Payments.csproj" />
 	</ItemGroup>
 

--- a/tests/TailoredApps.Shared.Payments.Tests/appsettings.json
+++ b/tests/TailoredApps.Shared.Payments.Tests/appsettings.json
@@ -1,13 +1,19 @@
 ﻿{
-    "Payments": {
-        "Providers": {
-          "Cashbill": {
-            "ReturnUrl": "https://integrationtest.tailoredapps.pl/positive",
-            "NegativeReturnUrl": "https://integrationtest.tailoredapps.pl/negative",
-            "ServiceUrl": "https://pay.cashbill.pl/testws/rest/",
-            "ShopId": "integrationtest.tailoredapps.pl",
-            "ShopSecretPhrase": "1c5dd47b1dd0e11ffc3e2b1595c3dd67"
-          }
-        }
+  "Payments": {
+    "Providers": {
+      "Cashbill": {
+        "ReturnUrl": "https://integrationtest.tailoredapps.pl/positive",
+        "NegativeReturnUrl": "https://integrationtest.tailoredapps.pl/negative",
+        "ServiceUrl": "https://pay.cashbill.pl/testws/rest/",
+        "ShopId": "integrationtest.tailoredapps.pl",
+        "ShopSecretPhrase": "1c5dd47b1dd0e11ffc3e2b1595c3dd67"
+      },
+      "Stripe": {
+        "SecretKey": "sk_test_REPLACE_ME",
+        "WebhookSecret": "whsec_REPLACE_ME",
+        "SuccessUrl": "https://integrationtest.tailoredapps.pl/payment/success?session={CHECKOUT_SESSION_ID}",
+        "CancelUrl": "https://integrationtest.tailoredapps.pl/payment/cancel"
+      }
     }
+  }
 }


### PR DESCRIPTION
## Nowy provider płatności — Stripe Checkout

### Co dodano

#### `src/TailoredApps.Shared.Payments.Provider.Stripe/`
- **`StripeProvider`** — implementuje `IPaymentProvider` (Key=`"Stripe"`)
- **`StripeServiceCaller`** — wrapper nad `Stripe.net` SDK z per-request `ApiKey` (multi-tenant safe, brak globalnego `StripeConfiguration.ApiKey`)
- **`IStripeServiceCaller`** — abstrakcja umożliwiająca mockowanie w testach
- **`StripeServiceOptions`** — sekcja `Payments:Providers:Stripe` (SecretKey, WebhookSecret, SuccessUrl, CancelUrl)
- **`StripeConfigureOptions`** + **`StripeProviderExtensions.RegisterStripeProvider()`** — analogia do `RegisterCashbillProvider()`

#### Przepływ płatności
```
RegisterPayment() → Stripe Checkout Session → RedirectUrl (hosted page)
GetStatus()       → Session.Status + PaymentStatus → PaymentStatusEnum
TransactionStatusChange() → weryfikacja HMAC-SHA256 → obsługa eventu
```

#### Metody płatności per waluta
| Waluta | Kanały |
|--------|--------|
| PLN | card, blik, p24 |
| EUR | card, sepa_debit |
| inne | card |

#### Mapowanie statusów
| Stripe | PaymentStatusEnum |
|--------|------------------|
| Session open | Created |
| Session complete + paid | Finished |
| Session complete + unpaid | Processing |
| Session expired | Rejected |
| checkout.session.completed (paid) | Finished |
| checkout.session.expired | Rejected |
| Nieprawidłowy podpis webhooka | Rejected |

### Testy
- **`StripeWebhookSignatureTests`** (4 testy jednostkowe, nie wymagają połączenia):
  - valid signature → sukces
  - invalid signature → `StripeException`
  - stale timestamp (>300s) → `StripeException` (ochrona przed replay attacks)
  - tampered payload → `StripeException`
- **`StripePaymentTest`** (smoke + integracyjne):
  - providers list contains Stripe
  - GetChannels PLN → blik+p24+card
  - GetChannels EUR → card+sepa
  - GetChannels USD → only card
  - invalid webhook signature → Rejected (bez wyjątku na zewnątrz)
  - 2× `[Skip]` integration tests (wymagają `sk_test_...` w env)

### Użycie (analogia do CashBill w zalejpajaca.pl)
```csharp
builder.Services.RegisterStripeProvider();
builder.Services.AddPayments()
    .RegisterPaymentProvider<StripeProvider>();
```

`appsettings.json`:
```json
{
  "Payments": {
    "Providers": {
      "Stripe": {
        "SecretKey": "sk_live_...",
        "WebhookSecret": "whsec_...",
        "SuccessUrl": "https://example.com/payment/success?session={CHECKOUT_SESSION_ID}",
        "CancelUrl": "https://example.com/payment/cancel"
      }
    }
  }
}
```

### Zależności
- `Stripe.net` v47 (oficjalny SDK)
- Multi-target: net8.0, net9.0, net10.0 (analogia do CashBill)