### PR TITLE
ci: add NuGet publish steps for Stripe, Adyen, PayU, Przelewy24, Tpay, HotPay, PayNow, Revolut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,4 +82,36 @@ jobs:
       working-directory: src/TailoredApps.Shared.Email.Office365/bin/Release
       run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
       continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.Stripe/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.Adyen/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.PayU/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.Przelewy24/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.Tpay/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.HotPay/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.PayNow/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
+    - name: Dotnet Nuget Push   
+      working-directory: src/TailoredApps.Shared.Payments.Provider.Revolut/bin/Release
+      run: dotnet nuget push TailoredApps.Shared.*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+      continue-on-error: true
       


### PR DESCRIPTION
Dodaje kroki `dotnet nuget push` w `release.yml` dla wszystkich nowych providerów płatności:

- `TailoredApps.Shared.Payments.Provider.Stripe`
- `TailoredApps.Shared.Payments.Provider.Adyen`
- `TailoredApps.Shared.Payments.Provider.PayU`
- `TailoredApps.Shared.Payments.Provider.Przelewy24`
- `TailoredApps.Shared.Payments.Provider.Tpay`
- `TailoredApps.Shared.Payments.Provider.HotPay`
- `TailoredApps.Shared.Payments.Provider.PayNow`
- `TailoredApps.Shared.Payments.Provider.Revolut`

Każdy krok ma `continue-on-error: true` (zgodnie z istniejącym wzorcem).
Publikacja triggeruje się na tagu `v*` — bez zmian w logice release.