### PR TITLE
docs: tłumaczenia UI MkDocs — language: pl + alternate PL/EN selector

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
 # Configuration
 theme:
   name: material
+  language: pl
   features:
     - announce.dismiss
     - content.action.edit
@@ -118,6 +119,13 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/tailored-apps/SharedComponents
+  alternate:
+    - name: Polski
+      link: /
+      lang: pl
+    - name: English
+      link: /en/
+      lang: en
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
Zmiana w `mkdocs.yml`:
- `theme.language: pl` — cały UI dokumentacji w języku polskim (wyszukiwarka, nawigacja, ToC, przyciski)
- `extra.alternate` — language selector PL/EN w nagłówku strony

Rebased cleanly na master.