### PR TITLE
Fix bump-deps workflow YAML parser error

### DIFF
--- a/.github/workflows/bump-deps.yml
+++ b/.github/workflows/bump-deps.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    env:
+      ALLOWED_LICENSES: ${{ github.event.inputs.allowed-licenses || 'MIT,Apache-2.0' }}
+      DRY_RUN: ${{ github.event.inputs.dry-run || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,23 +40,23 @@ jobs:
         id: bump
         shell: pwsh
         run: |
-          $licenses = '${{ inputs.allowed-licenses || ''MIT,Apache-2.0'' }}' -split ','
-          $dryRun = '${{ inputs.dry-run }}' -eq 'true'
-          $args = @{
+          $licenses = $env:ALLOWED_LICENSES -split ','
+          $dryRun = $env:DRY_RUN -eq 'true'
+          $scriptArgs = @{
             AllowedLicenses = $licenses
             GithubOutput    = $true
           }
-          if ($dryRun) { $args.DryRun = $true }
-          ./scripts/Bump-Deps.ps1 @args
+          if ($dryRun) { $scriptArgs.DryRun = $true }
+          ./scripts/Bump-Deps.ps1 @scriptArgs
 
       - name: Verify build
-        if: steps.bump.outputs.bumped == 'true' && inputs.dry-run != 'true'
+        if: steps.bump.outputs.bumped == 'true' && env.DRY_RUN != 'true'
         run: |
           dotnet restore TailoredApps.Shared.sln
           dotnet build TailoredApps.Shared.sln --no-restore --nologo
 
       - name: Create pull request
-        if: steps.bump.outputs.bumped == 'true' && inputs.dry-run != 'true'
+        if: steps.bump.outputs.bumped == 'true' && env.DRY_RUN != 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: 'chore(deps): automated dependency bump'
@@ -61,7 +64,7 @@ jobs:
           body: |
             Automated bump produced by `.github/workflows/bump-deps.yml`.
 
-            Allowed licenses: `${{ inputs.allowed-licenses || 'MIT,Apache-2.0' }}`
+            Allowed licenses: `${{ env.ALLOWED_LICENSES }}`
 
             ### Bumps and skips
             See workflow run log for the full BUMP/SKIP report.


### PR DESCRIPTION
## Summary
PR #37's squash merge landed an earlier draft of `.github/workflows/bump-deps.yml`. The follow-up fix commit was pushed to that branch but never merged. As a result master's workflow currently fails to parse with:

> (Line: 39, Col: 14): Unexpected symbol: `'0'''`. Located at position 43 within expression: `inputs.allowed-licenses || ''MIT,Apache-2.0''`

Triggering the workflow (manually or via cron) currently fails. This PR lands the fix on its own.

## Changes
- Hoist defaults to job-level `env:` (`ALLOWED_LICENSES`, `DRY_RUN`) — PowerShell reads plain `$env:VAR`, no `${{ }}` interpolation inside the `run:` body.
- Use `github.event.inputs.*` (defined on `workflow_dispatch`, `null` on `schedule`) so the `||` fallback resolves cleanly on cron runs.
- `if:` guards on `Verify build` / `Create pull request` now use `env.DRY_RUN`.
- Rename `$args` → `$scriptArgs` (PowerShell automatic-variable collision).

## Test plan
- [x] Verified locally — file parses
- [ ] After merge: `gh workflow run .github/workflows/bump-deps.yml --field dry-run=true` should succeed
- [ ] Confirm scheduled run on next Monday 06:00 UTC executes without parser error

🤖 Generated with [Claude Code](https://claude.com/claude-code)