### PR TITLE
docs governance: mandatory docs rule + enforcement (pre-push hook, CI gate, release notes)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Pre-push guard: library changes under src/ must ship with documentation
+# updates under docs/ and docs-en/ (see DOCUMENTATION_RULE.md).
+#
+# Enable once per clone:   git config core.hooksPath .githooks
+# Bypass a single push:    SKIP_DOCS_CHECK=1 git push
+#
+# This is fast local feedback only. The authoritative, un-bypassable check is
+# the "Docs guard" GitHub Actions workflow on the pull request.
+
+if [ "$SKIP_DOCS_CHECK" = "1" ]; then
+	exit 0
+fi
+
+zero=0000000000000000000000000000000000000000
+fail=0
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+	# Branch deletion — nothing to inspect.
+	if [ "$local_sha" = "$zero" ]; then
+		continue
+	fi
+
+	if [ "$remote_sha" = "$zero" ]; then
+		# New branch on the remote: diff against the merge-base with master.
+		base=$(git merge-base origin/master "$local_sha" 2>/dev/null || echo "")
+	else
+		base="$remote_sha"
+	fi
+
+	# Can't determine a range — defer to the CI gate rather than false-block.
+	if [ -z "$base" ]; then
+		continue
+	fi
+
+	changed=$(git diff --name-only "$base" "$local_sha")
+	code=$(printf '%s\n' "$changed" | grep -E '^src/' || true)
+	docs=$(printf '%s\n' "$changed" | grep -E '^(docs|docs-en)/' || true)
+
+	if [ -n "$code" ] && [ -z "$docs" ]; then
+		fail=1
+	fi
+done
+
+if [ "$fail" = "1" ]; then
+	echo "" >&2
+	echo "  Push blocked: library code under src/ changed without documentation." >&2
+	echo "  Update docs/Libraries/<Name>/index.md and docs-en/Libraries/<Name>/index.md" >&2
+	echo "  (see DOCUMENTATION_RULE.md), or bypass once with:" >&2
+	echo "" >&2
+	echo "      SKIP_DOCS_CHECK=1 git push" >&2
+	echo "" >&2
+	exit 1
+fi
+
+exit 0

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+# Configuration for GitHub's auto-generated release notes.
+# Applied when a release is created with generated notes (see the
+# "Release notes" workflow, or the "Generate release notes" button).
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: 🚀 New libraries
+      labels:
+        - new-library
+    - title: ✨ Features
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: ⬆️ Dependencies
+      labels:
+        - dependencies
+    - title: 🔧 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -1,0 +1,52 @@
+name: Docs guard
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  require-docs:
+    name: Docs required for library changes
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-docs') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail when src changes ship without docs
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          echo "Changed files:"
+          echo "$changed"
+          code="$(echo "$changed" | grep -E '^src/' || true)"
+          docs="$(echo "$changed" | grep -E '^(docs|docs-en)/' || true)"
+          if [ -n "$code" ] && [ -z "$docs" ]; then
+            echo "::error::Library code under src/ changed but no docs/ or docs-en/ updates were found. Update the library docs (see DOCUMENTATION_RULE.md) or add the 'skip-docs' label to this PR."
+            exit 1
+          fi
+          echo "OK: documentation updated, or no library code changed."
+
+  strict-build:
+    name: mkdocs build --strict
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Build Polish site (strict)
+        run: mkdocs build --config-file mkdocs.yml --strict --site-dir /tmp/site-pl
+
+      - name: Build English site (strict)
+        run: mkdocs build --config-file mkdocs-en.yml --strict --site-dir /tmp/site-en

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,31 @@
+name: Release notes
+
+# Creates a GitHub Release with auto-generated, categorised notes whenever a
+# version tag is pushed. Note categories are configured in .github/release.yml.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create release with generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists — skipping."
+          else
+            gh release create "$tag" --verify-tag --generate-notes --title "$tag"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,3 +61,14 @@ tells an AI coding agent how to wire the library into a project. It must state:
 - XML doc comments on every public type and member (`<GenerateDocumentationFile>True</GenerateDocumentationFile>`).
 
 When in doubt, mirror an existing page such as `docs/Libraries/EntityFramework/UnitOfWork.WebApiCore.md`.
+
+## Enforcement
+- **CI (blocking):** the *Docs guard* workflow (`.github/workflows/docs-guard.yml`) fails a PR when
+  `src/**` changed without matching `docs/**` + `docs-en/**` updates (escape hatch: add the `skip-docs`
+  label), and runs `mkdocs build --strict` for both sites. Add both checks to branch protection so they
+  block merge.
+- **Local (pre-push):** enable the shared hook once per clone — `git config core.hooksPath .githooks`.
+  It blocks a push that changes `src/**` without docs. Bypass a single push with `SKIP_DOCS_CHECK=1 git push`.
+- **Changelog:** GitHub Releases are generated from merged PRs on every `v*` tag; note categories live in
+  `.github/release.yml`. Label PRs (`new-library`, `feature`, `bug`, `documentation`, `dependencies`) so
+  they group correctly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Build & Test Commands
+
+## Build
+- Build solution: `dotnet build TailoredApps.Shared.sln`
+- Build specific project: `dotnet build src/TailoredApps.Shared.DateTime/TailoredApps.Shared.DateTime.csproj`
+
+## Test
+- Run all tests: `dotnet test TailoredApps.Shared.sln`
+- Run specific test project: `dotnet test tests/TailoredApps.Shared.DateTime.Tests/TailoredApps.Shared.DateTime.Tests.csproj`
+- Run single test: `dotnet test --filter "FullyQualifiedName=TailoredApps.Shared.DateTime.Tests.DateTimeProviderTests.As_Library_User_When_Get_Now_I_Get_Mine_System_Date_In_Current_Timezone_And_Local_Kind"`
+
+# Code Style Guidelines
+
+## Naming Conventions
+- Use PascalCase for class, method, property, interface names
+- Interface names should start with "I" (e.g., `IDateTimeProvider`)
+- Use descriptive names for types and members
+- Use verb phrases for method names (e.g., `SendMail`)
+
+## Code Organization
+- Use namespaces that match directory structure
+- Group related functionality in dedicated projects
+- XML documentation on public interfaces and classes
+
+## Error Handling
+- Use exceptions for exceptional cases, not control flow
+- Validate method arguments with explicit checks
+
+## Testing
+- Use xUnit for unit tests
+- Test method naming format: `When_Condition_Should_ExpectedBehavior`
+- Arrange-Act-Assert pattern for test structure
+
+# Documentation (mandatory for every library)
+
+Documentation is part of "done". Any PR that adds or changes a shared library MUST include its
+documentation in the **same PR** — a PR without it is incomplete and will be rejected.
+`DOCUMENTATION_RULE.md` is the authoritative spec; always follow it. The essentials:
+
+## Docs spec — always include
+- A library page in **both** languages: `docs/Libraries/<Name>/index.md` (Polish) and
+  `docs-en/Libraries/<Name>/index.md` (English).
+- Each page, in this order: header + NuGet/License badges → description → installation
+  (`dotnet add package ...`) → DI registration (`Program.cs`) → real usage example → API Reference
+  table → **🤖 AI Agent Prompt** section.
+- Register the page in the `nav` of **both** `mkdocs.yml` and `mkdocs-en.yml`.
+- Add a row to the library table in **both** `docs/index.md` and `docs-en/index.md`.
+- `mkdocs build --strict` must pass for both configs (no orphan pages, no broken links). Never leave a
+  stray page outside the nav.
+
+## AI-setup spec — always include
+Every library page MUST carry a `## 🤖 AI Agent Prompt` section: a ready-to-paste prompt block that
+tells an AI coding agent how to wire the library into a project. It must state:
+- **Registration** — the exact `Program.cs` calls.
+- **What gets configured** — the public surface.
+- **Configuration** — the keys or options.
+- **Rules** — the dos and don'ts the agent must follow.
+
+## Package- and IDE-facing docs
+- A `README.md` in the library project, packed into the NuGet package via `<PackageReadmeFile>`.
+- XML doc comments on every public type and member (`<GenerateDocumentationFile>True</GenerateDocumentationFile>`).
+
+When in doubt, mirror an existing page such as `docs/Libraries/EntityFramework/UnitOfWork.WebApiCore.md`.


### PR DESCRIPTION
## Summary

Makes the documentation rule real: a written standard **plus** the enforcement to back it, and a home for "what changed" per release.

## 1. The rule (`CLAUDE.md`)
Adds `CLAUDE.md` to the repo (was local-only) with a mandatory **Documentation** section: every PR touching a library must ship bilingual docs (`docs/` + `docs-en/`), nav + index-table entries, an XML-doc''d public API, a packed NuGet `README.md`, and — per your ask — a **🤖 AI Agent Prompt** (the AI-setup spec) on every page. References `DOCUMENTATION_RULE.md`.

## 2. Enforcement
- **Pre-push hook** (`.githooks/pre-push`): blocks a push that changes `src/**` without `docs/**` + `docs-en/**` updates. Enable once per clone with `git config core.hooksPath .githooks`; bypass a single push with `SKIP_DOCS_CHECK=1 git push`. Fast local feedback.
- **CI gate** (`.github/workflows/docs-guard.yml`, on `pull_request`):
  - `require-docs` — fails when `src/**` changes ship without docs (escape hatch: `skip-docs` label)
  - `strict-build` — runs `mkdocs build --strict` for **both** sites (catches orphan pages / broken nav / dead links)
  - Make both **required status checks** in branch protection to make them un-bypassable.

## 3. Changelog → GitHub Releases
- `.github/release.yml` — categorises auto-generated notes by PR label (New libraries / Features / Fixes / Docs / Dependencies).
- `.github/workflows/release-notes.yml` — creates a GitHub Release with generated notes on every `v*` tag.

## Verified locally
- Pre-push hook: `sh -n` clean; blocks `src`-without-docs, passes `src`+docs; LF line endings.
- `mkdocs build --strict` passes for both sites on current `master`, so the new required check is green from day one.
- All workflow YAML lints clean.

## Manual step (repo settings)
Add **`require-docs`** and **`mkdocs build --strict`** as required status checks under branch protection for `master`. I can do this via `gh api` if you want — just say the word.

Scope: governance/CI only, no library or build changes. Complements the WebApi library in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)